### PR TITLE
Migration to CoreBluetoothMock framework

### DIFF
--- a/MockingExample.xcodeproj/project.pbxproj
+++ b/MockingExample.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		F0A6C9E5299B95BF00FA75EB /* Data+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A6C9E4299B95BF00FA75EB /* Data+String.swift */; };
 		F0CC18AB29C0914300077C3E /* CoreBluetoothMock in Frameworks */ = {isa = PBXBuildFile; productRef = F0CC18AA29C0914300077C3E /* CoreBluetoothMock */; };
 		F0CC18AD29C092E000077C3E /* Aliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CC18AC29C092E000077C3E /* Aliases.swift */; };
+		F0CC18B029C099EB00077C3E /* Blinky.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CC18AF29C099EB00077C3E /* Blinky.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +79,7 @@
 		F0A6C9E1299649A500FA75EB /* ForEachWithIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForEachWithIndex.swift; sourceTree = "<group>"; };
 		F0A6C9E4299B95BF00FA75EB /* Data+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+String.swift"; sourceTree = "<group>"; };
 		F0CC18AC29C092E000077C3E /* Aliases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Aliases.swift; sourceTree = "<group>"; };
+		F0CC18AF29C099EB00077C3E /* Blinky.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Blinky.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -130,6 +132,7 @@
 		F0A6C9942992752700FA75EB /* MockingExample */ = {
 			isa = PBXGroup;
 			children = (
+				F0CC18AE29C099D300077C3E /* Mocks */,
 				F0A6C9E3299671F600FA75EB /* Screens */,
 				F0A6C9D229944BA500FA75EB /* Model */,
 				F0A6C9D129944B9400FA75EB /* Views */,
@@ -210,6 +213,14 @@
 				F0A6C9C5299295ED00FA75EB /* DeviceScreen.swift */,
 			);
 			path = Screens;
+			sourceTree = "<group>";
+		};
+		F0CC18AE29C099D300077C3E /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				F0CC18AF29C099EB00077C3E /* Blinky.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -358,6 +369,7 @@
 				F0A6C9D429944BCF00FA75EB /* Colors.swift in Sources */,
 				F0A6C9D02993D45800FA75EB /* DetailsView.swift in Sources */,
 				F0A6C9E5299B95BF00FA75EB /* Data+String.swift in Sources */,
+				F0CC18B029C099EB00077C3E /* Blinky.swift in Sources */,
 				F0A6C9E2299649A500FA75EB /* ForEachWithIndex.swift in Sources */,
 				F0A6C9982992752700FA75EB /* ScannerScreen.swift in Sources */,
 				F0A6C9CE2993D3F600FA75EB /* ServicesView.swift in Sources */,

--- a/MockingExample.xcodeproj/project.pbxproj
+++ b/MockingExample.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		F0A6C9E0299544B100FA75EB /* Attribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A6C9DF299544B100FA75EB /* Attribute.swift */; };
 		F0A6C9E2299649A500FA75EB /* ForEachWithIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A6C9E1299649A500FA75EB /* ForEachWithIndex.swift */; };
 		F0A6C9E5299B95BF00FA75EB /* Data+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A6C9E4299B95BF00FA75EB /* Data+String.swift */; };
+		F0CC18AB29C0914300077C3E /* CoreBluetoothMock in Frameworks */ = {isa = PBXBuildFile; productRef = F0CC18AA29C0914300077C3E /* CoreBluetoothMock */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +83,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F0CC18AB29C0914300077C3E /* CoreBluetoothMock in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -223,6 +225,9 @@
 			dependencies = (
 			);
 			name = MockingExample;
+			packageProductDependencies = (
+				F0CC18AA29C0914300077C3E /* CoreBluetoothMock */,
+			);
 			productName = MockingExample;
 			productReference = F0A6C9922992752700FA75EB /* MockingExample.app */;
 			productType = "com.apple.product-type.application";
@@ -295,6 +300,9 @@
 				Base,
 			);
 			mainGroup = F0A6C9892992752700FA75EB;
+			packageReferences = (
+				F0CC18A929C0914300077C3E /* XCRemoteSwiftPackageReference "IOS-CoreBluetooth-Mock" */,
+			);
 			productRefGroup = F0A6C9932992752700FA75EB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -718,6 +726,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		F0CC18A929C0914300077C3E /* XCRemoteSwiftPackageReference "IOS-CoreBluetooth-Mock" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.16.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F0CC18AA29C0914300077C3E /* CoreBluetoothMock */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F0CC18A929C0914300077C3E /* XCRemoteSwiftPackageReference "IOS-CoreBluetooth-Mock" */;
+			productName = CoreBluetoothMock;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = F0A6C98A2992752700FA75EB /* Project object */;
 }

--- a/MockingExample.xcodeproj/project.pbxproj
+++ b/MockingExample.xcodeproj/project.pbxproj
@@ -749,7 +749,7 @@
 			repositoryURL = "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.16.0;
+				minimumVersion = 1.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/MockingExample.xcodeproj/project.pbxproj
+++ b/MockingExample.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		F0A6C9E2299649A500FA75EB /* ForEachWithIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A6C9E1299649A500FA75EB /* ForEachWithIndex.swift */; };
 		F0A6C9E5299B95BF00FA75EB /* Data+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0A6C9E4299B95BF00FA75EB /* Data+String.swift */; };
 		F0CC18AB29C0914300077C3E /* CoreBluetoothMock in Frameworks */ = {isa = PBXBuildFile; productRef = F0CC18AA29C0914300077C3E /* CoreBluetoothMock */; };
+		F0CC18AD29C092E000077C3E /* Aliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0CC18AC29C092E000077C3E /* Aliases.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +77,7 @@
 		F0A6C9DF299544B100FA75EB /* Attribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attribute.swift; sourceTree = "<group>"; };
 		F0A6C9E1299649A500FA75EB /* ForEachWithIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForEachWithIndex.swift; sourceTree = "<group>"; };
 		F0A6C9E4299B95BF00FA75EB /* Data+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+String.swift"; sourceTree = "<group>"; };
+		F0CC18AC29C092E000077C3E /* Aliases.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Aliases.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +137,7 @@
 				F0A6C9C72992982400FA75EB /* Strings.swift */,
 				F0A6C9D329944BCF00FA75EB /* Colors.swift */,
 				F0A6C9E4299B95BF00FA75EB /* Data+String.swift */,
+				F0CC18AC29C092E000077C3E /* Aliases.swift */,
 				F0A6C9C92993015B00FA75EB /* Info.plist */,
 				F0A6C9992992752700FA75EB /* Assets.xcassets */,
 				F0A6C99B2992752700FA75EB /* MockingExample.entitlements */,
@@ -347,6 +350,7 @@
 			files = (
 				F0A6C9C42992778700FA75EB /* ScannedPeripheral.swift in Sources */,
 				F0A6C9DE2994EA4600FA75EB /* IncludedService.swift in Sources */,
+				F0CC18AD29C092E000077C3E /* Aliases.swift in Sources */,
 				F0A6C9DA2994EA3100FA75EB /* Characteristic.swift in Sources */,
 				F0A6C9DC2994EA3E00FA75EB /* Descriptor.swift in Sources */,
 				F0A6C9E0299544B100FA75EB /* Attribute.swift in Sources */,

--- a/MockingExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MockingExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,15 @@
 {
+  "originHash" : "8f88fa74b2dfdbad97b45e62c3e24b487896b1740df9d299e38a7a9332b4feb1",
   "pins" : [
     {
       "identity" : "ios-corebluetooth-mock",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock",
       "state" : {
-        "revision" : "d46a187d37d515f56f9d65376ad315b9581d50f9",
-        "version" : "0.16.0"
+        "revision" : "f82391f3f74efeafba443782f49869d8f75bb948",
+        "version" : "1.0.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/MockingExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MockingExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "ios-corebluetooth-mock",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock",
+      "state" : {
+        "revision" : "d46a187d37d515f56f9d65376ad315b9581d50f9",
+        "version" : "0.16.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/MockingExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MockingExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock",
       "state" : {
-        "revision" : "f82391f3f74efeafba443782f49869d8f75bb948",
-        "version" : "1.0.0"
+        "revision" : "a6bc354a97948fddcf0fa8d1ad707b9e88b21fbd",
+        "version" : "1.0.2"
       }
     }
   ],

--- a/MockingExample/Aliases.swift
+++ b/MockingExample/Aliases.swift
@@ -1,0 +1,87 @@
+/*
+* Copyright (c) 2020, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import CoreBluetoothMock
+
+// Copy this file to your project to start using CoreBluetoothMock classes
+// without having to refactor any of your code. You will just have to remove
+// the imports to CoreBluetooth to fix conflicts and initiate the manager
+// using CBCentralManagerFactory, instad of just creating a CBCentralManager.
+
+// disabled for Xcode 12.5 beta
+//typealias CBPeer                          = CBMPeer
+//typealias CBAttribute                     = CBMAttribute
+typealias CBCentralManagerFactory         = CBMCentralManagerFactory
+typealias CBUUID                          = CBMUUID
+typealias CBError                         = CBMError
+typealias CBATTError                      = CBMATTError
+typealias CBManagerState                  = CBMManagerState
+typealias CBPeripheralState               = CBMPeripheralState
+typealias CBCentralManager                = CBMCentralManager
+typealias CBCentralManagerDelegate        = CBMCentralManagerDelegate
+typealias CBPeripheral                    = CBMPeripheral
+typealias CBPeripheralDelegate            = CBMPeripheralDelegate
+typealias CBService                       = CBMService
+typealias CBCharacteristic                = CBMCharacteristic
+typealias CBCharacteristicWriteType       = CBMCharacteristicWriteType
+typealias CBCharacteristicProperties      = CBMCharacteristicProperties
+typealias CBDescriptor                    = CBMDescriptor
+typealias CBConnectionEvent               = CBMConnectionEvent
+typealias CBConnectionEventMatchingOption = CBMConnectionEventMatchingOption
+@available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+typealias CBL2CAPPSM                      = CBML2CAPPSM
+@available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+typealias CBL2CAPChannel                  = CBML2CAPChannel
+
+let CBCentralManagerScanOptionAllowDuplicatesKey       = CBMCentralManagerScanOptionAllowDuplicatesKey
+let CBCentralManagerOptionShowPowerAlertKey            = CBMCentralManagerOptionShowPowerAlertKey
+let CBCentralManagerOptionRestoreIdentifierKey         = CBMCentralManagerOptionRestoreIdentifierKey
+let CBCentralManagerScanOptionSolicitedServiceUUIDsKey = CBMCentralManagerScanOptionSolicitedServiceUUIDsKey
+let CBConnectPeripheralOptionStartDelayKey             = CBMConnectPeripheralOptionStartDelayKey
+#if !os(macOS)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+let CBConnectPeripheralOptionRequiresANCS              = CBMConnectPeripheralOptionRequiresANCS
+#endif
+let CBCentralManagerRestoredStatePeripheralsKey        = CBMCentralManagerRestoredStatePeripheralsKey
+let CBCentralManagerRestoredStateScanServicesKey       = CBMCentralManagerRestoredStateScanServicesKey
+let CBCentralManagerRestoredStateScanOptionsKey        = CBMCentralManagerRestoredStateScanOptionsKey
+
+let CBAdvertisementDataLocalNameKey                    = CBMAdvertisementDataLocalNameKey
+let CBAdvertisementDataServiceUUIDsKey                 = CBMAdvertisementDataServiceUUIDsKey
+let CBAdvertisementDataIsConnectable                   = CBMAdvertisementDataIsConnectable
+let CBAdvertisementDataTxPowerLevelKey                 = CBMAdvertisementDataTxPowerLevelKey
+let CBAdvertisementDataServiceDataKey                  = CBMAdvertisementDataServiceDataKey
+let CBAdvertisementDataManufacturerDataKey             = CBMAdvertisementDataManufacturerDataKey
+let CBAdvertisementDataOverflowServiceUUIDsKey         = CBMAdvertisementDataOverflowServiceUUIDsKey
+let CBAdvertisementDataSolicitedServiceUUIDsKey        = CBMAdvertisementDataSolicitedServiceUUIDsKey
+
+let CBConnectPeripheralOptionNotifyOnConnectionKey     = CBMConnectPeripheralOptionNotifyOnConnectionKey
+let CBConnectPeripheralOptionNotifyOnDisconnectionKey  = CBMConnectPeripheralOptionNotifyOnDisconnectionKey
+let CBConnectPeripheralOptionNotifyOnNotificationKey   = CBMConnectPeripheralOptionNotifyOnNotificationKey

--- a/MockingExample/MockingExampleApp.swift
+++ b/MockingExample/MockingExampleApp.swift
@@ -13,6 +13,7 @@ struct MockingExampleApp: App {
     
     init() {
         CBMCentralManagerMock.simulateInitialState(.poweredOn)
+        CBMCentralManagerMock.simulatePeripherals([blinky])
     }
     
     var body: some Scene {

--- a/MockingExample/MockingExampleApp.swift
+++ b/MockingExample/MockingExampleApp.swift
@@ -6,9 +6,15 @@
 //
 
 import SwiftUI
+import CoreBluetoothMock
 
 @main
 struct MockingExampleApp: App {
+    
+    init() {
+        CBMCentralManagerMock.simulateInitialState(.poweredOn)
+    }
+    
     var body: some Scene {
         WindowGroup {
             ScannerScreen()

--- a/MockingExample/Mocks/Blinky.swift
+++ b/MockingExample/Mocks/Blinky.swift
@@ -1,0 +1,135 @@
+//
+//  Mocks.swift
+//  MockingExample
+//
+//  Created by Aleksander Nowakowski on 14/02/2023.
+//
+
+import Foundation
+import CoreBluetoothMock
+
+// MARK: - Constants
+
+extension CBMUUID {
+    static let nordicBlinkyService  = CBMUUID(string: "00001523-1212-EFDE-1523-785FEABCD123")
+    static let buttonCharacteristic = CBMUUID(string: "00001524-1212-EFDE-1523-785FEABCD123")
+    static let ledCharacteristic    = CBMUUID(string: "00001525-1212-EFDE-1523-785FEABCD123")
+}
+
+// MARK: - Services
+
+extension CBMCharacteristicMock {
+    
+    static let buttonCharacteristic = CBMCharacteristicMock(
+        type: .buttonCharacteristic,
+        properties: [.notify, .read],
+        descriptors: CBMClientCharacteristicConfigurationDescriptorMock()
+    )
+
+    static let ledCharacteristic = CBMCharacteristicMock(
+        type: .ledCharacteristic,
+        properties: [.write, .read]
+    )
+    
+}
+
+extension CBMServiceMock {
+
+    static let blinkyService = CBMServiceMock(
+        type: .nordicBlinkyService,
+        primary: true,
+        characteristics:
+            .buttonCharacteristic,
+            .ledCharacteristic
+    )
+    
+}
+
+// MARK: - Blinky Implementation
+
+/// The delegate implements the behavior of the mocked device.
+private class BlinkyCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
+    
+    // MARK: States
+    
+    /// State of the LED.
+    private var ledEnabled: Bool = false
+    /// State of the Button.
+    private var buttonPressed: Bool = false
+    
+    // MARK: Encoders
+    
+    /// LED state encoded as Data.
+    ///
+    /// - 0x01 - LED is ON.
+    /// - 0x00 - LED is OFF.
+    private var ledData: Data {
+        return ledEnabled ? Data([0x01]) : Data([0x00])
+    }
+    
+    /// Button state encoded as Data.
+    ///
+    /// - 0x01 - Button is pressed.
+    /// - 0x00 - Button is released.
+    private var buttonData: Data {
+        return buttonPressed ? Data([0x01]) : Data([0x00])
+    }
+    
+    // MARK: Event handlers
+
+    func reset() {
+        ledEnabled = false
+        buttonPressed = false
+    }
+
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
+            -> Result<Data, Error> {
+        if characteristic.uuid == .ledCharacteristic {
+            return .success(ledData)
+        } else {
+            return .success(buttonData)
+        }
+    }
+    
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveWriteRequestFor characteristic: CBMCharacteristicMock,
+                    data: Data) -> Result<Void, Error> {
+        if data.count > 0 {
+            ledEnabled = data[0] != 0x00
+        }
+        return .success(())
+    }
+}
+
+// MARK: - Blinky Definition
+
+/// This device will advertise with 2 different types of packets, as nRF Blinky and an iBeacon (with a name).
+/// As iOS prunes the iBeacon manufacturer data, only the name is available.
+let blinky = CBMPeripheralSpec
+    .simulatePeripheral(proximity: .immediate)
+    .advertising(
+        advertisementData: [
+            CBAdvertisementDataIsConnectable : true as NSNumber,
+            CBAdvertisementDataLocalNameKey : "Blinky"
+        ],
+        withInterval: 2.0,
+        delay: 5.0,
+        alsoWhenConnected: false
+    )
+    .advertising(
+        advertisementData: [
+            CBAdvertisementDataIsConnectable : false as NSNumber,
+            CBAdvertisementDataLocalNameKey : "iBeacon",
+            //CBAdvertisementDataManufacturerDataKey:
+        ],
+        withInterval: 4.0,
+        delay: 2.0,
+        alsoWhenConnected: false
+    )
+    .connectable(
+        name: "nRF Blinky",
+        services: [.blinkyService],
+        delegate: BlinkyCBMPeripheralSpecDelegate()
+    )
+    .build()

--- a/MockingExample/Screens/DeviceScreen.swift
+++ b/MockingExample/Screens/DeviceScreen.swift
@@ -130,7 +130,11 @@ extension DeviceScreen {
             super.init()
             
             // Try to connect even if a non-connectable packet was received.
-            self.centralManager = CBCentralManager(delegate: self, queue: .main)
+            
+            // If you're creating the central manager in multiple places, set the `forceMock`
+            // parameter to the same value.
+            self.centralManager = CBCentralManagerFactory.instance(delegate: self, queue: .main,
+                                                                   forceMock: false)
         }
         
         func connect() {

--- a/MockingExample/Screens/DeviceScreen.swift
+++ b/MockingExample/Screens/DeviceScreen.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import CoreBluetooth
+import CoreBluetoothMock
 
 enum ConnectionState {
     case disconnected
@@ -269,3 +270,17 @@ extension Data {
     }
     
 }
+
+// As this screen requires an instance of CBPeripheral,
+// a CBMPeripheralPreview may be used.
+// Such object does not need to be obtained using scanner,
+// and handles all requests with default values.
+//
+// You may override CBMPeripheralPreview to achieve custom behavior.
+struct DeviceScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        let peripheral = ScannedPeripheral(CBMPeripheralPreview(blinky))
+        DeviceScreen(peripheral)
+    }
+}
+

--- a/MockingExample/Screens/ScannerScreen.swift
+++ b/MockingExample/Screens/ScannerScreen.swift
@@ -116,3 +116,11 @@ extension ScannerScreen.ViewModel: CBCentralManagerDelegate {
     }
     
 }
+
+// This Preview displays advertising mock peripherals.
+// No additional configuration required.
+struct ScannerView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScannerScreen()
+    }
+}


### PR DESCRIPTION
This PR migrates the project from *CoreBluetooth* to *CoreBluetoothMock* framework.

Follow commit for step-by-step migration:
1. 950f56e - Add *CoreBluetoothMock* dependency using Swift Package Manager (SPM).
2. c4627f4 - Adding *Aliases.swift* file and fixing compilation errors:
   a. `CBCentralManager` initialization changed to use `CBMCentralManagerFactory`.
   b. Applying a change needed if `CBPeripheral` instances were compared with each other.
3. c2baba0 - Setting initial state of the manager to `.poweredOn`. By default, the manager is initially disabled.
4. fe743a8 - Adding a mock peripheral implementation.

The mocking framework can also be used to render SwiftUI Previews:
1. e3d5fcc - Mock peripherals will show up on scanner screen just as if run on a Simulator.
2. ad3de93 - If an instance of `CBPeripheral` is needed in a Preview, a special `CBMPeripheralPreview` class can be used.